### PR TITLE
hotfix: Urls.py ausencia de coma

### DIFF
--- a/ustudy/urls.py
+++ b/ustudy/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
     path('subir_contenido/', views.subir_contenido),
     path('suscripcion/', views.suscripcion),
     path('curso/<int:id_curso>/archivo/<int:id_archivo>', views.ver_archivo),
-    path('registro/', views.registro_usuario)
+    path('registro/', views.registro_usuario),
     path('curso/<int:id_curso>/archivo/<int:id_archivo>/reporte/<int:id_reporte>', views.eliminar_reporte),
     path('perfil/', views.perfil_usuario),
     path('pago/',views.pago)


### PR DESCRIPTION
Se ha detectado la falta de una coma en el path "/registro"